### PR TITLE
Removed hardcoded relative path (for KC 26.x)

### DIFF
--- a/src/http.js
+++ b/src/http.js
@@ -18,7 +18,7 @@ const agent = new https.Agent({
 const tokenConfig = {
     httpsAgent : agent,
     method: 'post',
-    url: config.keycloakServerBaseURL + '/auth/realms/' + config.adminRealm + '/protocol/openid-connect/token',
+    url: config.keycloakServerBaseURL + '/realms/' + config.adminRealm + '/protocol/openid-connect/token',
     headers: {
         'Content-Type': 'application/x-www-form-urlencoded'
     },
@@ -47,7 +47,7 @@ exports.httpCallKeycloakImportConfig = function (idPsMetadataUrl) {
         let axiosConfig = {
             httpsAgent : agent,
             method: 'post',
-            url: config.keycloakServerBaseURL + '/auth/admin/realms/' + config.realm + '/identity-provider/import-config',
+            url: config.keycloakServerBaseURL + '/admin/realms/' + config.realm + '/identity-provider/import-config',
             headers: {
                 'Authorization': 'Bearer ' + token,
                 'Content-Type': 'application/json'
@@ -70,7 +70,7 @@ exports.httpCallKeycloakCreateIdP = function (idPModel) {
         let axiosConfig = {
             httpsAgent : agent,
             method: 'post',
-            url: config.keycloakServerBaseURL + '/auth/admin/realms/' + config.realm + '/identity-provider/instances',
+            url: config.keycloakServerBaseURL + '/admin/realms/' + config.realm + '/identity-provider/instances',
             headers: {
                 'Authorization': 'Bearer ' + token,
                 'Content-Type': 'application/json'
@@ -91,7 +91,7 @@ exports.httpCallKeycloakDeleteIdP = function (idPAlias) {
         let axiosConfig = {
             httpsAgent : agent,
             method: 'delete',
-            url: config.keycloakServerBaseURL + '/auth/admin/realms/' + config.realm + '/identity-provider/instances/' + idPAlias,
+            url: config.keycloakServerBaseURL + '/admin/realms/' + config.realm + '/identity-provider/instances/' + idPAlias,
             headers: {
                 'Authorization': 'Bearer ' + token,
                 'Content-Type': 'application/json'
@@ -110,7 +110,7 @@ exports.httpCallKeycloakGetIpds = function () {
         let axiosConfig = {
             httpsAgent : agent,
             method: 'get',
-            url: config.keycloakServerBaseURL + '/auth/admin/realms/' + config.realm + '/identity-provider/instances',
+            url: config.keycloakServerBaseURL + '/admin/realms/' + config.realm + '/identity-provider/instances',
             headers: {
                 'Authorization': 'Bearer ' + token,
                 'Content-Type': 'application/json'
@@ -128,7 +128,7 @@ exports.httpCallKeycloakGetIpdDescription = function (idpAlias) {
     let axiosConfig = {
         httpsAgent : agent,
         method: 'get',
-        url: config.keycloakServerBaseURL + '/auth/realms/' + config.realm + '/broker/' + encodeURIComponent(idpAlias) + '/endpoint/descriptor',
+        url: config.keycloakServerBaseURL + '/realms/' + config.realm + '/broker/' + encodeURIComponent(idpAlias) + '/endpoint/descriptor',
     };
     return axios(axiosConfig)
         .catch(function (error) {
@@ -155,7 +155,7 @@ const httpCallKeycloakCreateMapper = function (idPAlias, mapperModel) {
         let axiosConfig = {
             httpsAgent : agent,
             method: 'post',
-            url: config.keycloakServerBaseURL + '/auth/admin/realms/' + config.realm + '/identity-provider/instances/' + idPAlias + '/mappers',
+            url: config.keycloakServerBaseURL + '/admin/realms/' + config.realm + '/identity-provider/instances/' + idPAlias + '/mappers',
             headers: {
                 'Authorization': 'Bearer ' + token,
                 'Content-Type': 'application/json'


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Removed hardcoded '/auth' from Keycloak URLs in `src/http.js` for Keycloak 26.x compatibility.
> 
>   - **Behavior**:
>     - Removed hardcoded '/auth' from Keycloak URLs in `src/http.js`.
>     - Affects `tokenConfig`, `httpCallKeycloakImportConfig`, `httpCallKeycloakCreateIdP`, `httpCallKeycloakDeleteIdP`, `httpCallKeycloakGetIpds`, `httpCallKeycloakGetIpdDescription`, and `httpCallKeycloakCreateMapper`.
>   - **Misc**:
>     - Ensures compatibility with Keycloak 26.x by updating URL paths.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=nicolabeghin%2Fkeycloak-cieid-provider-configuration-client&utm_source=github&utm_medium=referral)<sup> for 07903a323c77e9800894767fa5342b4426b7e3c4. You can [customize](https://app.ellipsis.dev/nicolabeghin/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->