### PR TITLE
Handle import-config failures gracefully

### DIFF
--- a/createidps.js
+++ b/createidps.js
@@ -1,5 +1,5 @@
 const {from, of, concat} = require('rxjs')
-const {concatMap, map, mergeMap, take, delay} = require('rxjs/operators')
+const {concatMap, map, mergeMap, take, delay, filter} = require('rxjs/operators')
 const {config, patchTemplate, enrichIdpWithConfigData} = require('./src/common')
 const {
     httpCallKeycloakImportConfig,
@@ -47,15 +47,21 @@ var getKeycloakImportConfigModels$ = deleteKeycloakSpidIdPs$
     .pipe(concatMap(spidIdPOfficialMetadata => of(spidIdPOfficialMetadata)
         .pipe(
             delay(1500), // workaround for ClosedChannelException (HTTP error 503) from Keycloak 26.1
-            mergeMap(spidIdPOfficialMetadata => 
+            mergeMap(spidIdPOfficialMetadata =>
                 from(httpCallKeycloakImportConfig(spidIdPOfficialMetadata.metadata_url)
-                    .then(httpResponse => {return [spidIdPOfficialMetadata, httpResponse.data];}))
+                    .then(httpResponse => {
+                        if (!httpResponse) {
+                            return null;
+                        }
+                        return [spidIdPOfficialMetadata, httpResponse.data];
+                    }))
             )
         )
     ));
 
 //trasformazione ed arricchimento => modello per creare l'idP su keycloak
 var enrichedModels$ = getKeycloakImportConfigModels$
+    .pipe(filter(item => item !== null))
     .pipe(map(spidIdPOfficialMetadataWithImportConfigModel => {
         let [idPOfficialMetadata, importConfigModel] = spidIdPOfficialMetadataWithImportConfigModel
         importConfigModel.validateSignature = true; // override import config from metadata

--- a/src/http.js
+++ b/src/http.js
@@ -170,12 +170,23 @@ const httpCallKeycloakCreateMapper = function (idPAlias, mapperModel) {
 }
 
 const handleHttpError = function(error) {
-    if (undefined !== error.response.data.errorMessage) {
-        console.error(error.response.data.errorMessage);
+    if (error.response) {
+        const {status, statusText, data, config: reqConfig} = error.response;
+        console.error(`HTTP ${status} ${statusText || ''} on ${reqConfig?.method?.toUpperCase?.()} ${reqConfig?.url}`);
+        if (data && typeof data === 'object') {
+            if (data.errorMessage) console.error('errorMessage:', data.errorMessage);
+            if (data.error) console.error('error:', data.error);
+            if (data.error_description) console.error('error_description:', data.error_description);
+            console.error('response body:', JSON.stringify(data));
+        } else if (data) {
+            console.error('response body:', String(data));
+        }
         return;
     }
-    if (undefined !== error.response.data.error) {
-        console.error(error.response.data.error);
+    if (error.request) {
+        console.error(`No response received (network/timeout) on ${error.config?.method?.toUpperCase?.()} ${error.config?.url}`);
+        console.error('cause:', error.code || error.message);
         return;
     }
+    console.error('Request setup error:', error.message);
 }


### PR DESCRIPTION
## Summary
- Improve `handleHttpError` in `src/http.js` to log HTTP status, URL, and response body, so failures surface real diagnostic info instead of a generic "unknown_error".
- Null-guard the import-config pipeline in `createidps.js` so a failed metadata import skips that IdP instead of crashing the whole script with `TypeError: Cannot read properties of undefined (reading 'data')`.

## Motivation
When Keycloak cannot reach an IdP metadata URL (e.g. network/firewall blocking outbound 443 to the SPID/CIE metadata host), the admin REST call to `/identity-provider/import-config` returns HTTP 500 with body `{"error":"unknown_error"}`. The previous error handler accessed `error.response.data.errorMessage` unconditionally and returned nothing, causing the downstream `.then` to receive `undefined` and crash.

## Test plan
- [x] Run `npm run create-idps` against a Keycloak instance where one metadata URL is unreachable: verify the script logs status/URL/body for the failing call and continues with the other IdPs instead of crashing.
- [x] Run against a fully reachable environment: verify IdPs are still created and mappers configured as before.